### PR TITLE
Tentative fix of issue #2

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+Please see README.md

--- a/support/grdiff.c
+++ b/support/grdiff.c
@@ -209,7 +209,7 @@ int read_stats(stats_t *stats, FILE *file){
 		}
 		if (gstrsub(line, "  Size") == 0){
 			// stats->size = atoi(line + strlen("  Size ");
-			stats->size = atoi(line + 7);
+			stats->size = atoll(line + 7);
 			size_set = 1;
 		};
 		if (strcmp(line, "  Type reg\n") == 0){

--- a/support/gstats.h
+++ b/support/gstats.h
@@ -30,7 +30,7 @@ struct stats {
     unsigned int gid;
                   
     int type;
-    unsigned long long size;
+    long long size;
     nlink_t nlink; 
     time_t ctime; 
     time_t atime; 


### PR DESCRIPTION
This is a tentative fix of issue #2.

The edit consists of properly parsing `long long` values.
Signed `long long` is used for storing sizes, because [it is what Posix mandates](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html#tag_13_67).
(credit goes to the answers of [this question on Stack Overflow](https://stackoverflow.com/questions/9073667/where-to-find-the-complete-definition-of-off-t-type)).

A dummy `README` file is also added, otherwise `autoreconf` would not run on my system.

Unfortunately, I have no way to test this... testers are welcome!