### PR TITLE
Use pkg-config to find fuse libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS=rdiff-backup-fs
 
-LDADD = layout/liblayout.a structure/libstructure.a retriever/libretriever.a support/libsupport.a
+LDADD = layout/liblayout.a structure/libstructure.a retriever/libretriever.a support/libsupport.a $(FUSE_LIBS)
 
 rdiff_backup_fs_SOURCES=rdiff-backup-fs.c errors.c errors.h parse.c parse.h \
 						initialize.c initialize.h operations.c operations.h \

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 AC_PREREQ(2.61)
-AC_INIT(rdiff-backup-fs, 1.0.0)
+AC_INIT(rdiff-backup-fs, 1.0.1)
 
 AC_CANONICAL_HOST
 AC_PROG_RANLIB
 
-AM_INIT_AUTOMAKE(rdiff-backup-fs, 1.0.0)
+AM_INIT_AUTOMAKE(rdiff-backup-fs, 1.0.1)
 AC_CONFIG_HEADER(config.h)
 AC_CONFIG_FILES([Makefile layout/Makefile structure/Makefile retriever/Makefile support/Makefile])
 
@@ -15,7 +15,7 @@ AC_PROG_CC
 dnl checks for libraries
 
 AC_CHECK_LIB([z], [gzgets],,[AC_MSG_ERROR(No zlib library!)])
-AC_CHECK_LIB(fuse, fuse_main, FUSE_LIBS="-lfuse", AC_MSG_ERROR(No fuse library!))
+PKG_CHECK_MODULES([FUSE], [fuse], [], [AC_MSG_ERROR(No fuse library!)])
 
 dnl checks for header files
 


### PR DESCRIPTION
Should allow building on modern Linux hosts (partially fix of issue #4)

Please note that this is my own work, and is not based on the [Debian package patches](https://packages.debian.org/source/buster/rdiff-backup-fs).
(I read about the Debian package just after committing this)
Integrating the other patches from the Debian package is beyond my current purposes, and could be a possibly better alternative than merging this PR.